### PR TITLE
Update influxdata.repo.j2 fix for RPM based OS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ telegraf_runas_group: telegraf
 
 # Configuration Template
 telegraf_configuration_template: telegraf.conf.j2
+telegraf_configuration_backup: true
 
 # Configuration Variables
 telegraf_tags:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,7 @@
     src: "{{ telegraf_configuration_template }}"
     dest: "{{ telegraf_configuration_dir }}/telegraf.conf"
     force: true
-    backup: true
+    backup: "{{ telegraf_configuration_backup }}"
     owner: telegraf
     group: telegraf
     mode: 0744

--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -17,5 +17,5 @@ baseurl = {{ telegraf_influxdata_base_url }}/{{ ansible_distribution|lower }}/$r
 {% endif %}
 enabled = 1
 gpgcheck = 1
-gpgkey = {{ telegraf_influxdata_base_url }}/influxdb.key
+gpgkey = {{ telegraf_influxdata_base_url }}/influxdata-archive_compat.key
 sslverify = 1


### PR DESCRIPTION
keyname changed also for yum repos to influxdata-archive_compat.key